### PR TITLE
Fixes copy-paste mistake in usage.txt

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -33,7 +33,7 @@ peermaps generate INFILE {OPTIONS}
   --xmin      Minimum longitude (west). Default: -180
   --xmax      Maximum longitude (east). Default: 180
   --ymin      Minimum latitude (south). Default: -90
-  --ymin      Maximum latitude (north). Default: 90
+  --ymax      Maximum latitude (north). Default: 90
   --xcount    Number of longitude divisions per branch. Default: 4
   --ycount    Number of latitude divisions per branch. Default: 4
   --nproc     Number of converter processes to spawn. Default: (`nproc`-1)

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ peermaps generate INFILE {OPTIONS}
   --xmin      Minimum longitude (west). Default: -180
   --xmax      Maximum longitude (east). Default: 180
   --ymin      Minimum latitude (south). Default: -90
-  --ymin      Maximum latitude (north). Default: 90
+  --ymax      Maximum latitude (north). Default: 90
   --xcount    Number of longitude divisions per branch. Default: 4
   --ycount    Number of latitude divisions per branch. Default: 4
   --nproc     Number of converter processes to spawn. Default: (`nproc`-1)


### PR DESCRIPTION
I noticed a small mistake in the usage.txt, shown on --help: `--ymin` is listed twice, `--ymax` omited. This PR fixes that.