### PR TITLE
Feature/output default

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -71,13 +71,15 @@ if (argv.help || argv._[0] === 'help') {
   })
 } else if (argv._[0] === 'generate') {
   var wsen = argv.extents ? argv.extents.split(/[ ,]/).map(Number) : []
-  mkdirp(argv.outdir, function (err) {
+  var outdir = defined(argv.outdir, './mapdata')
+
+  mkdirp(outdir, function (err) {
     if (err) return error(err)
     require('../lib/generate')({
       debug: argv.debug !== false,
       infile: argv._[1] || argv.infile,
       threshold: inbytes(argv.threshold || '1M'),
-      outdir: argv.outdir,
+      outdir: outdir,
       remove: 1,
       xmin: defined(argv.xmin, wsen[0], -180),
       xmax: defined(argv.xmax, wsen[2], 180),


### PR DESCRIPTION
Running generate without the `-o` option resulted in an error:

````
path.js:28
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:28:11)
    at Object.resolve (path.js:1171:7)
    at mkdirP (/usr/local/lib/node_modules/peermaps/node_modules/mkdirp/index.js:25:14)
    at Object.<anonymous> (/usr/local/lib/node_modules/peermaps/bin/cmd.js:74:3)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
```

This patch sets a default and uses that if not provided in the -o flag.