### PR TITLE
Feature/fs address

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -31,7 +31,7 @@ if (argv.network === 'ipfs') {
   network = require('../network/dat.js')(
     argv.dir || path.join(ospath.data(), 'peermaps/dat'))
 } else if (argv.network === 'fs') {
-  network = require('../network/fs.js')()
+  network = require('../network/fs.js')(process.cwd())
 }
 
 var peermaps = require('../')({ network: network })

--- a/network/fs.js
+++ b/network/fs.js
@@ -10,6 +10,9 @@ module.exports = function (dir) {
     },
     address: function (cb) {
       cb(null, dir)
+    },
+    close: function (cb) {
+      if (cb) cb()
     }
   }
 }


### PR DESCRIPTION
Running `peermaps address -n fs` caused an error, because `.close()` was not defined on the fs adapter. Adding that.

Also rendering the cwd on `peermaps address -n fs` instead of `undefined`.